### PR TITLE
Remove circular-json

### DIFF
--- a/src/dashbot.js
+++ b/src/dashbot.js
@@ -4,7 +4,6 @@ var rp = require('request-promise');
 var uuid = require('node-uuid');
 var _ = require('lodash');
 const util = require('util');
-const cJSON = require('circular-json');
 
 var VERSION = '0.7.2';
 


### PR DESCRIPTION
This module is not used in `dashbot.js` and it will cause 

```bash
Error: Cannot find module 'circular-json'
```

after `npm install dashbot` since it was listed in `devDependencies` instead of`dependencies`.