### PR TITLE
Fix the bug send method for kik doesn't return Promise

### DIFF
--- a/src/dashbot.js
+++ b/src/dashbot.js
@@ -285,7 +285,7 @@ function DashBotKik(apiKey, urlRoot, debug, printErrors) {
       internalLogOutgoing(data, 'kiknpm');
     });
 
-    that.botHandle.originalSend(newMessages, recipient, chatId);
+    return that.botHandle.originalSend(newMessages, recipient, chatId);
   }
 
   function messageToObject(message) {


### PR DESCRIPTION
Original bot.send() method of Kik returns Promise to handle asynchronously, but the method you overwrote doesn't return the Promise. When we write below code, an error is happening.
```
bot.send('test').then(()=>{
  console.log('test')
})