### PR TITLE
#15 add support for template tag to Facebook for botkit

### DIFF
--- a/examples/facebook-example-botkit.js
+++ b/examples/facebook-example-botkit.js
@@ -47,3 +47,10 @@ controller.on('facebook_optin', function(bot, message) {
 controller.on('message_received', function(bot, message) {
   bot.reply(message,  'You are right when you say '+message.text);
 });
+
+controller.hears('hello world', 'message_received', function(bot, message) {
+  // add template tag to the next message sent
+  dashbot.addTemplateTag(message, 'hello-world');
+
+  bot.reply(message, 'hi');
+});

--- a/src/dashbot-facebook.js
+++ b/src/dashbot-facebook.js
@@ -14,7 +14,8 @@ function DashBotFacebook(apiKey, urlRoot, debug, printErrors) {
   that.urlRoot = urlRoot;
   that.debug = debug;
   that.printErrors = printErrors;
-  that.eventLogger = new EventLogger(apiKey, urlRoot, debug, printErrors)
+  that.eventLogger = new EventLogger(apiKey, urlRoot, debug, printErrors);
+  that.templateIds = {};
 
   function logIncomingInternal(data, source, type) {
     type = type || 'incoming'
@@ -66,6 +67,13 @@ function DashBotFacebook(apiKey, urlRoot, debug, printErrors) {
     return that.eventLogger.logEvent(that.platform, data, 'npm');
   }
 
+  that.addTemplateTag = function(message, templateId) {
+    if (!that.templateIds[message.channel]) {
+      that.templateIds[message.channel] = [];
+    }
+    that.templateIds[message.channel].push(templateId);
+  }
+
   function getAndRemove(obj, prop) {
     var temp = obj[prop];
     delete obj[prop];
@@ -100,6 +108,7 @@ function DashBotFacebook(apiKey, urlRoot, debug, printErrors) {
         access_token: bot.botkit.config.access_token
       },
       json: {
+        dashbotTemplateId: that.templateIds[message.channel] ? that.templateIds[message.channel].shift() : undefined,
         recipient: {
           id: channel
         },


### PR DESCRIPTION
#15 add support for template tag to Facebook for botkit
* add `dashbotTemplateId` in `botkitTransformOutgoing`
* add `addTemplateTag` method
* update example on usage

Calling `addTemplateTag` will queue up a template tag to be added to the next message logged to Dashbot