### PR TITLE
Return google logging promises

### DIFF
--- a/src/dashbot-google.js
+++ b/src/dashbot-google.js
@@ -114,7 +114,7 @@ function DashBotGoogle(apiKey, urlRoot, debug, printErrors, config) {
     if (intent) {
       data.intent = intent
     }
-    internalLogIncoming(data, 'npm');
+    return internalLogIncoming(data, 'npm');
   };
 
   that.logOutgoing = function(requestBody, message, metadata) {
@@ -127,7 +127,7 @@ function DashBotGoogle(apiKey, urlRoot, debug, printErrors, config) {
     if (metadata) {
       data.metadata = metadata
     }
-    internalLogOutgoing(data, 'npm');
+    return internalLogOutgoing(data, 'npm');
   };
 
   return that;

--- a/src/make-request.js
+++ b/src/make-request.js
@@ -27,9 +27,9 @@ module.exports = function (data, printErrors, redact, timeout = 15000) {
       }
       return response
     })
-  } else {
-    p.catch(function(err) {
-      // ignore
-    });
   }
+
+  return p.catch(function(err) {
+    // ignore
+  })
 }


### PR DESCRIPTION
When logging request and responses using the Google Assistant, we expect a promise response, but since the framework does not return them, our code sometimes crashes, or we need to set up a timeout to stop the waiting time.