### PR TITLE
Update lodash to fix security vulnerability in lodash 4.17.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2909,9 +2909,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "dashbot-logger": "^1.0.4",
     "es6-promise": "4.1.0",
     "isomorphic-fetch": "2.2.1",
-    "lodash": "4.17.10",
+    "lodash": "^4.17.11",
     "meld": "1.3.2",
     "redact-pii": "1.3.1",
     "traverse": "0.6.6",


### PR DESCRIPTION
@Cognigy is using this package and we are really happy with it! Sadly we realised, that you are using an outdated version of lodash that contains security vulnerabilities. The whole repository has some security vulnerabilities - but the lodash one is really severe. Hence creating this PR to help you get it fixed :)!

Would be awesome if you could review it and release a 10.3.4 of your package on NPM!